### PR TITLE
Add SIGQUIT event handler

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -99,6 +99,10 @@ process.on('SIGINT', function() {
   child.destroy()
 })
 
+process.on('SIGQUIT', function() {
+  child.destroy()
+})
+
 process.on('SIGTERM', function() {
   child.destroy()
 })


### PR DESCRIPTION
I have an app that uses a `SIGQUIT` signal to terminate a process.
IMO this should also be supported.
