### PR TITLE
Add version and host to opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ var endsWith = function(str, suffix) {
 var run = function(image, opts) {
   if (!opts) opts = {}
 
-  var request = docker(opts.host, {version:'v1.14'})
+  var request = docker({host: opts.host, version: opts.version || 'v1.21'})
   var that = new events.EventEmitter()
   var tty = !!opts.tty
 


### PR DESCRIPTION
This PR allows the docker version to be specified and not be hardcoded to an out of date version.